### PR TITLE
Adding references to STM32F1xx

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@
 | usb_stmv1  | GCC C      | 8         | Internal S/N, Doublebuffered | STM32L1xx  |
 | usb_stmv1a | GCC ASM    | 8         | Internal S/N, Doublebuffered | STM32L1xx  |
 | usb_stmv2  | GCC C      | 6         | Internal S/N, Doublebuffered, BC1.2 | STM32L4x5 STM32L4x6 (OTG FS (Device mode)) |
-| usb_stmv3  | GCC C      | 8         | Internal S/N, Doublebuffered | STM32F303  |
+| usb_stmv3  | GCC C      | 8         | Internal S/N, Doublebuffered | STM32F1xx STM32F3xx  |
 
 1. Single physical endpoint can be used to implement
   + one bi-directional/single-buffer logical endpoint (CONTROL)
@@ -23,7 +23,7 @@
 
 2. At this moment BULK IN endpoint can use both buffers, but it is not **real** doublebuffered.
 
-3. Tested with STM32L052, STM31L100, STM32L476RG, STM32F303CC
+3. Tested with STM32L052, STM31L100, STM32L476RG, STM32F103CB, STM32F303CC
 
 ### Implemented definitions for classes ###
 1. USB HID based on [Device Class Definition for Human Interface Devices (HID) Version 1.11](http://www.usb.org/developers/hidpage/HID1_11.pdf)

--- a/usb.h
+++ b/usb.h
@@ -43,7 +43,12 @@
     #endif
 #elif defined(STM32L476xx)
     #define USE_STMV2_DRIVER
-#elif defined(STM32F303xC) || defined(STM32F303xE)
+#elif defined(STM32F102x6) || defined(STM32F102xB) || \
+      defined(STM32F103x6) || defined(STM32F103xB) || \
+      defined(STM32F103xE) || defined(STM32F103xG) || \
+      defined(STM32F302x8) || defined(STM32F302xC) || defined(STM32F302xE) || \
+      defined(STM32F303xC) || defined(STM32F303xE) || \
+      defined(STM32F373xC)
     #define USE_STMV3_DRIVER
 #else
     #error Unsupported STM32 family


### PR DESCRIPTION
I have achieved enumeration on STM32F103CB using the V3 driver. From the datasheets and reference manuals, it is safe to assume compatibility between STM32F102, F103, F302, F303 and F373 parts.

The F1 and F3 chips lacked internal DP pull-up control. Thus the usbd_connect function really does nothing.