### PR TITLE
Adding stdbool to usbd_core.h

### DIFF
--- a/inc/usbd_core.h
+++ b/inc/usbd_core.h
@@ -19,6 +19,8 @@
     extern "C" {
 #endif
 
+#include <stdbool.h>
+
 /**\addtogroup USBD_HW_CORE USB Device HW driver and core API
  * @{ */
 #if defined(__DOXYGEN__)


### PR DESCRIPTION
Way too many times had I be bitten by this: usbd_core.h depends on stdbool.h, but it does not `#include` it directly for some reason. I just added it there so it won't bite in the future again.

And regarding C++, stdbool.h is usually safe to C++.