### PR TITLE
Fix MAX_EP. I though it was the total number of endpoints but by the …

### DIFF
--- a/src/usbd_stm32f105_otgfs.c
+++ b/src/usbd_stm32f105_otgfs.c
@@ -21,7 +21,7 @@
 
 #if defined(USBD_STM32F105)
 
-#define MAX_EP          6
+#define MAX_EP          3
 #define MAX_RX_PACKET   128
 #define MAX_CONTROL_EP  1
 #define MAX_FIFO_SZ     320  /*in 32-bit chunks */


### PR DESCRIPTION
…way it is used in the code shows that it is the number of endpoint pairs (IN/OUT) not counting EP0.

I realized this and fixed it when applying the changes to the usbd_stm32f429_otgfs.c file to support the stm32f105. But that commit didn't get merged.