### PR TITLE
Avoid ModemManager blocking the virtual serial port

### DIFF
--- a/demo/cdc_loop.c
+++ b/demo/cdc_loop.c
@@ -35,6 +35,7 @@
 #define CDC_LOOPBACK
 #define ENABLE_HID_COMBO
 
+//#define SIGNAL_MODEM  /* uncomment to signal modem capabilities */
 //#define CDC_USE_IRQ   /* uncomment to build interrupt-based demo */
 
 /* Declaration of the report descriptor */
@@ -124,7 +125,11 @@ static const struct cdc_config config_desc = {
         .bNumEndpoints          = 1,
         .bInterfaceClass        = USB_CLASS_CDC,
         .bInterfaceSubClass     = USB_CDC_SUBCLASS_ACM,
+        #ifdef SIGNAL_MODEM
         .bInterfaceProtocol     = USB_CDC_PROTO_V25TER,
+        #else
+        .bInterfaceProtocol     = USB_CDC_PROTO_NONE,
+        #endif
         .iInterface             = NO_DESCRIPTOR,
     },
     .cdc_hdr = {

--- a/inc/usb_cdc.h
+++ b/inc/usb_cdc.h
@@ -39,6 +39,7 @@
 
 /**\name Communications Class Protocol Codes
  * @{ */
+#define USB_CDC_PROTO_NONE              0x00    /**<\brief No class specific protocol required */
 #define USB_CDC_PROTO_V25TER            0x01    /**<\brief AT Commands: V.250 etc.*/
  /** @} */
 


### PR DESCRIPTION
With current udev, if ModemManager is running and CDC class device signals AT support, then access to `/dev/ttyACMx` is blocked for about 10 seconds until ModemManager gives up. This can be avoided by not signaling AT modem command support (see https://gitlab.freedesktop.org/mobile-broadband/ModemManager/issues/111 for discussion of same issue).