### PR TITLE
fix 'align' keyword place

### DIFF
--- a/src/usbd_stm32l052_devfs_asm.S
+++ b/src/usbd_stm32l052_devfs_asm.S
@@ -89,8 +89,8 @@
     .cpu cortex-m0plus
     .thumb
 
-    .align  4
     .section .rodata.usbd_devfs_asm
+    .align  4
     .globl  usbd_devfs_asm
 usbd_devfs_asm:
     .long   _getinfo


### PR DESCRIPTION
It is very critical for Cortex-M0, because M0 has no hardware aligner :)