### PR TITLE
STM32WB55: fix suspend event bug

### DIFF
--- a/src/usbd_stm32wb55_devfs.c
+++ b/src/usbd_stm32wb55_devfs.c
@@ -417,8 +417,8 @@ static void evt_poll(usbd_device *dev, usbd_evt_callback callback) {
         USB->ISTR &= ~USB_ISTR_WKUP;
     } else if (_istr & USB_ISTR_SUSP) {
         _ev = usbd_evt_susp;
-        USB->CNTR |= USB_CNTR_FSUSP;
         USB->ISTR &= ~USB_ISTR_SUSP;
+        USB->CNTR |= USB_CNTR_FSUSP;
     } else if (_istr & USB_ISTR_ERR) {
         USB->ISTR &= ~USB_ISTR_ERR;
         _ev = usbd_evt_error;


### PR DESCRIPTION
I've found strange bug in WB55 USB controller: sometimes it stops getting wakeup event after entering suspended state first time. It seems to be some hardware issue, this bug also presents in HAL USB driver an even in built-in DFU bootloader. 
It can be fixed by clearing suspend interrupt flag before setting suspend command (which is wrong according to the datasheet, but it works)