### PR TITLE
Suppressing warnings on -Wextra for STM32WB55

### DIFF
--- a/src/usbd_core.c
+++ b/src/usbd_core.c
@@ -326,6 +326,7 @@ static void usbd_process_ep0 (usbd_device *dev, uint8_t event, uint8_t ep) {
         /* force switch to setup state */
         dev->status.control_state = usbd_ctl_idle;
         dev->complete_callback = 0;
+        /* fall through */
     case usbd_evt_eprx:
         usbd_process_eprx(dev, ep);
         break;

--- a/src/usbd_stm32wb55_devfs.c
+++ b/src/usbd_stm32wb55_devfs.c
@@ -94,7 +94,7 @@ static uint16_t get_next_pma(uint16_t sz) {
         if ((tbl->rx.addr) && (tbl->rx.addr < _result)) _result = tbl->rx.addr;
         if ((tbl->tx.addr) && (tbl->tx.addr < _result)) _result = tbl->tx.addr;
     }
-    return (_result < (0x020 + sz)) ? 0 : (_result - sz);
+    return (_result < (unsigned)(0x020 + sz)) ? 0 : (_result - sz);
 }
 
 static uint32_t getinfo(void) {


### PR DESCRIPTION
In our project https://github.com/flipperdevices/flipperzero-firmware, we enabled -Wextra for all code, and some warnings popped up in libusb_stm32 code we're using for STM32WB55.
This PR brings code to suppress them.