### PR TITLE
All ep_write functions take const buffer pointer.

### DIFF
--- a/inc/usbd_core.h
+++ b/inc/usbd_core.h
@@ -270,7 +270,7 @@ typedef int32_t (*usbd_hw_ep_read)(uint8_t ep, void *buf, uint16_t blen);
  * \param blen size of data will be written
  * \return number of written bytes
  */
-typedef int32_t (*usbd_hw_ep_write)(uint8_t ep, void *buf, uint16_t blen);
+typedef int32_t (*usbd_hw_ep_write)(uint8_t ep, const void *buf, uint16_t blen);
 
 /** Stalls and unstalls endpoint
  * \param ep endpoint address
@@ -419,7 +419,7 @@ inline static void usbd_reg_event(usbd_device *dev, uint8_t evt, usbd_evt_callba
  * \param dev dev usb device \ref _usbd_device
  * \copydetails usbd_hw_ep_write
  */
-inline static int32_t usbd_ep_write(usbd_device *dev, uint8_t ep, void *buf, uint16_t blen) {
+inline static int32_t usbd_ep_write(usbd_device *dev, uint8_t ep, const void *buf, uint16_t blen) {
     return dev->driver->ep_write(ep, buf, blen);
 }
 

--- a/src/usbd_stm32f103_devfs.c
+++ b/src/usbd_stm32f103_devfs.c
@@ -421,7 +421,7 @@ static void pma_write(const uint8_t *buf, uint16_t blen, pma_rec *tx) {
     }
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     pma_table *tbl = EPT(ep);
     volatile uint16_t *reg = EPR(ep);
     switch (*reg & (USB_EPTX_STAT | USB_EP_T_FIELD | USB_EP_KIND)) {

--- a/src/usbd_stm32f103_devfs_asm.S
+++ b/src/usbd_stm32f103_devfs_asm.S
@@ -493,7 +493,7 @@ _ep_read:
 
     .thumb_func
     .type   _ep_write, %function
-/* int32_t ep_write(uint8_t ep, void *buf, uint16_t blen)
+/* int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen)
  * R0 -> endpoint
  * R1 -> *buffer
  * R2 -> data length

--- a/src/usbd_stm32f105_otgfs.c
+++ b/src/usbd_stm32f105_otgfs.c
@@ -341,7 +341,7 @@ static int32_t ep_read(uint8_t ep, void* buf, uint16_t blen) {
     return (len < blen) ? len : blen;
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     uint32_t len, tmp;
     ep &= 0x7F;
     volatile uint32_t* fifo = EPFIFO(ep);
@@ -359,7 +359,7 @@ static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
     /* push data to FIFO */
     tmp = 0;
     for (int idx = 0; idx < blen; idx++) {
-        tmp |= (uint32_t)((uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
+        tmp |= (uint32_t)((const uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
         if ((idx & 0x03) == 0x03 || (idx + 1) == blen) {
             *fifo = tmp;
             tmp = 0;

--- a/src/usbd_stm32f429_otgfs.c
+++ b/src/usbd_stm32f429_otgfs.c
@@ -338,7 +338,7 @@ static int32_t ep_read(uint8_t ep, void* buf, uint16_t blen) {
     return (len < blen) ? len : blen;
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     uint32_t len, tmp;
     ep &= 0x7F;
     volatile uint32_t* fifo = EPFIFO(ep);
@@ -356,7 +356,7 @@ static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
     /* push data to FIFO */
     tmp = 0;
     for (int idx = 0; idx < blen; idx++) {
-        tmp |= (uint32_t)((uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
+        tmp |= (uint32_t)((const uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
         if ((idx & 0x03) == 0x03 || (idx + 1) == blen) {
             *fifo = tmp;
             tmp = 0;

--- a/src/usbd_stm32f429_otghs.c
+++ b/src/usbd_stm32f429_otghs.c
@@ -340,7 +340,7 @@ static int32_t ep_read(uint8_t ep, void* buf, uint16_t blen) {
     return (len < blen) ? len : blen;
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     uint32_t len, tmp;
     ep &= 0x7F;
     volatile uint32_t* fifo = EPFIFO(ep);
@@ -361,7 +361,7 @@ static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
     /* push data to FIFO */
     tmp = 0;
     for (int idx = 0; idx < blen; idx++) {
-        tmp |= (uint32_t)((uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
+        tmp |= (uint32_t)((const uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
         if ((idx & 0x03) == 0x03 || (idx + 1) == blen) {
             *fifo = tmp;
             tmp = 0;

--- a/src/usbd_stm32f446_otgfs.c
+++ b/src/usbd_stm32f446_otgfs.c
@@ -331,7 +331,7 @@ static int32_t ep_read(uint8_t ep, void* buf, uint16_t blen) {
     return (len < blen) ? len : blen;
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     uint32_t len, tmp;
     ep &= 0x7F;
     volatile uint32_t* fifo = EPFIFO(ep);
@@ -349,7 +349,7 @@ static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
     /* push data to FIFO */
     tmp = 0;
     for (int idx = 0; idx < blen; idx++) {
-        tmp |= (uint32_t)((uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
+        tmp |= (uint32_t)((const uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
         if ((idx & 0x03) == 0x03 || (idx + 1) == blen) {
             *fifo = tmp;
             tmp = 0;

--- a/src/usbd_stm32f446_otghs.c
+++ b/src/usbd_stm32f446_otghs.c
@@ -331,7 +331,7 @@ static int32_t ep_read(uint8_t ep, void* buf, uint16_t blen) {
     return (len < blen) ? len : blen;
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     uint32_t len, tmp;
     ep &= 0x7F;
     volatile uint32_t* fifo = EPFIFO(ep);
@@ -349,7 +349,7 @@ static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
     /* push data to FIFO */
     tmp = 0;
     for (int idx = 0; idx < blen; idx++) {
-        tmp |= (uint32_t)((uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
+        tmp |= (uint32_t)((const uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
         if ((idx & 0x03) == 0x03 || (idx + 1) == blen) {
             *fifo = tmp;
             tmp = 0;

--- a/src/usbd_stm32l052_devfs.c
+++ b/src/usbd_stm32l052_devfs.c
@@ -344,7 +344,7 @@ static int32_t ep_read(uint8_t ep, void *buf, uint16_t blen) {
     }
 }
 
-static void pma_write(uint8_t *buf, uint16_t blen, pma_rec *tx) {
+static void pma_write(const uint8_t *buf, uint16_t blen, pma_rec *tx) {
     uint16_t *pma = (void*)(USB_PMAADDR + tx->addr);
     uint16_t tmp = 0;
     tx->cnt = blen;
@@ -357,7 +357,7 @@ static void pma_write(uint8_t *buf, uint16_t blen, pma_rec *tx) {
     }
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     pma_table *tbl = EPT(ep);
     volatile uint16_t *reg = EPR(ep);
     switch (*reg & (USB_EPTX_STAT | USB_EP_T_FIELD | USB_EP_KIND)) {

--- a/src/usbd_stm32l052_devfs_asm.S
+++ b/src/usbd_stm32l052_devfs_asm.S
@@ -475,7 +475,7 @@ _ep_read:
 
     .thumb_func
     .type   _ep_write, %function
-/* int32_t ep_write(uint8_t ep, void *buf, uint16_t blen)
+/* int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen)
  * R0 -> endpoint
  * R1 -> *buffer
  * R2 -> data length

--- a/src/usbd_stm32l100_devfs.c
+++ b/src/usbd_stm32l100_devfs.c
@@ -331,7 +331,7 @@ static void pma_write(const uint8_t *buf, uint16_t blen, pma_rec *tx) {
     }
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     pma_table *tbl = EPT(ep);
     volatile uint16_t *reg = EPR(ep);
     switch (*reg & (USB_EPTX_STAT | USB_EP_T_FIELD | USB_EP_KIND)) {

--- a/src/usbd_stm32l100_devfs_asm.S
+++ b/src/usbd_stm32l100_devfs_asm.S
@@ -438,7 +438,7 @@ _ep_read:
 
     .thumb_func
     .type   _ep_write, %function
-/* int32_t ep_write(uint8_t ep, void *buf, uint16_t blen)
+/* int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen)
  * R0 -> endpoint
  * R1 -> *buffer
  * R2 -> data length

--- a/src/usbd_stm32l433_devfs.c
+++ b/src/usbd_stm32l433_devfs.c
@@ -335,7 +335,7 @@ static int32_t ep_read(uint8_t ep, void *buf, uint16_t blen) {
     }
 }
 
-static void pma_write(uint8_t *buf, uint16_t blen, pma_rec *tx) {
+static void pma_write(const uint8_t *buf, uint16_t blen, pma_rec *tx) {
     uint16_t *pma = (void*)(USB_PMAADDR + tx->addr);
     tx->cnt = blen;
     while (blen > 1) {
@@ -346,7 +346,7 @@ static void pma_write(uint8_t *buf, uint16_t blen, pma_rec *tx) {
     if (blen) *pma = *buf;
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     pma_table *tbl = EPT(ep);
     volatile uint16_t *reg = EPR(ep);
     switch (*reg & (USB_EPTX_STAT | USB_EP_T_FIELD | USB_EP_KIND)) {

--- a/src/usbd_stm32l476_otgfs.c
+++ b/src/usbd_stm32l476_otgfs.c
@@ -364,7 +364,7 @@ static int32_t ep_read(uint8_t ep, void* buf, uint16_t blen) {
     return (len < blen) ? len : blen;
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     uint32_t len, tmp;
     ep &= 0x7F;
     volatile uint32_t* fifo = EPFIFO(ep);
@@ -382,7 +382,7 @@ static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
     /* push data to FIFO */
     tmp = 0;
     for (int idx = 0; idx < blen; idx++) {
-        tmp |= (uint32_t)((uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
+        tmp |= (uint32_t)((const uint8_t*)buf)[idx] << ((idx & 0x03) << 3);
         if ((idx & 0x03) == 0x03 || (idx + 1) == blen) {
             *fifo = tmp;
             tmp = 0;

--- a/src/usbd_stm32wb55_devfs.c
+++ b/src/usbd_stm32wb55_devfs.c
@@ -335,7 +335,7 @@ static int32_t ep_read(uint8_t ep, void *buf, uint16_t blen) {
     }
 }
 
-static void pma_write(uint8_t *buf, uint16_t blen, pma_rec *tx) {
+static void pma_write(const uint8_t *buf, uint16_t blen, pma_rec *tx) {
     uint16_t *pma = (void*)(USB1_PMAADDR + tx->addr);
     tx->cnt = blen;
     while (blen > 1) {
@@ -346,7 +346,7 @@ static void pma_write(uint8_t *buf, uint16_t blen, pma_rec *tx) {
     if (blen) *pma = *buf;
 }
 
-static int32_t ep_write(uint8_t ep, void *buf, uint16_t blen) {
+static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     pma_table *tbl = EPT(ep);
     volatile uint16_t *reg = EPR(ep);
     switch (*reg & (USB_EPTX_STAT | USB_EP_T_FIELD | USB_EP_KIND)) {


### PR DESCRIPTION
This allows the functions users are providing that calls usbd_ep_write to use const pointers.