### PR TITLE
Add PlatformIO support

### DIFF
--- a/demo/cdc_loop.c
+++ b/demo/cdc_loop.c
@@ -16,7 +16,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 #include "usb_cdc.h"
 #include "usb_hid.h"

--- a/demo/cdc_startup.c
+++ b/demo/cdc_startup.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include "stm32.h"
+#include "stm32_compat.h"
 
 static void cdc_init_rcc (void) {
 #if defined(STM32L0)

--- a/inc/stm32_compat.h
+++ b/inc/stm32_compat.h
@@ -1,0 +1,59 @@
+#ifndef _STM32_COMPAT_H_
+#define _STM32_COMPAT_H_
+
+#ifndef PLATFORMIO
+
+#include <stm32.h>
+
+#else // PLATFORMIO
+/* modify bitfield */
+#define _BMD(reg, msk, val)     (reg) = (((reg) & ~(msk)) | (val))
+/* set bitfield */
+#define _BST(reg, bits)         (reg) = ((reg) | (bits))
+/* clear bitfield */
+#define _BCL(reg, bits)         (reg) = ((reg) & ~(bits))
+/* wait until bitfield set */
+#define _WBS(reg, bits)         while(((reg) & (bits)) == 0)
+/* wait until bitfield clear */
+#define _WBC(reg, bits)         while(((reg) & (bits)) != 0)
+/* wait for bitfield value */
+#define _WVL(reg, msk, val)     while(((reg) & (msk)) != (val))
+/* bit value */
+#define _BV(bit)                (0x01 << (bit))
+
+#if defined(STM32F0xx)
+    #include <stm32f0xx.h>
+#elif defined(STM32F1xx)
+    #include <stm32f1xx.h>
+#elif defined(STM32F2xx)
+    #include <stm32f2xx.h>
+#elif defined(STM32F3xx)
+    #include <stm32f3xx.h>
+#elif defined(STM32F4xx)
+    #include <stm32f4xx.h>
+#elif defined(STM32F7xx)
+    #include <stm32f7xx.h>
+#elif defined(STM32H7xx)
+    #include <stm32h7xx.h>
+#elif defined(STM32L0xx)
+    #include <stm32l0xx.h>
+#elif defined(STM32L1xx)
+    #include <stm32l1xx.h>
+#elif defined(STM32L4xx)
+    #include <stm32l4xx.h>
+#elif defined(STM32L5xx)
+    #include <stm32l5xx.h>
+#elif defined(STM32G0xx)
+    #include <stm32g0xx.h>
+#elif defined(STM32G4xx)
+    #include <stm32g4xx.h>
+#elif defined(STM32WBxx)
+    #include <stm32wbxx.h>
+#else
+    #error "STM32 family not defined"
+#endif
+
+#endif // PLATFORMIO
+
+
+#endif // _STM32_COMPAT_H_

--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+	"name": "libusb_stm32",
+	"description": "Lightweight USB Device Stack",
+	"version": "0.1.0",
+	"keywords": "stm32, usb",
+	"authors": {
+		"name": "Dmitry Filimonchuk",
+		"email": "dmitrystu@gmail.com"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/dmitrystu/libusb_stm32.git"
+	},
+	"frameworks": [ "cmsis", "stm32cube" ],
+	"platforms": [ "ststm32" ],
+	"headers": ["stm32_compat.h", "usb.h"],
+	"build": { "includeDir": "inc" }
+}

--- a/library.json
+++ b/library.json
@@ -11,7 +11,6 @@
 		"type": "git",
 		"url": "https://github.com/dmitrystu/libusb_stm32.git"
 	},
-	"frameworks": [ "cmsis", "stm32cube" ],
 	"platforms": [ "ststm32" ],
 	"headers": ["stm32_compat.h", "usb.h"],
 	"build": { "includeDir": "inc" }

--- a/src/usbd_stm32f103_devfs.c
+++ b/src/usbd_stm32f103_devfs.c
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32F103)

--- a/src/usbd_stm32f105_otgfs.c
+++ b/src/usbd_stm32f105_otgfs.c
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32F105)

--- a/src/usbd_stm32f429_otgfs.c
+++ b/src/usbd_stm32f429_otgfs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32F429FS)

--- a/src/usbd_stm32f429_otghs.c
+++ b/src/usbd_stm32f429_otghs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32F429HS)

--- a/src/usbd_stm32f446_otgfs.c
+++ b/src/usbd_stm32f446_otgfs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32F446FS)

--- a/src/usbd_stm32f446_otghs.c
+++ b/src/usbd_stm32f446_otghs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32F446HS)

--- a/src/usbd_stm32h743_otgfs.c
+++ b/src/usbd_stm32h743_otgfs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32H743FS)

--- a/src/usbd_stm32l052_devfs.c
+++ b/src/usbd_stm32l052_devfs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32L052)

--- a/src/usbd_stm32l100_devfs.c
+++ b/src/usbd_stm32l100_devfs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32L100)

--- a/src/usbd_stm32l433_devfs.c
+++ b/src/usbd_stm32l433_devfs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32L433)

--- a/src/usbd_stm32l476_otgfs.c
+++ b/src/usbd_stm32l476_otgfs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32L476)

--- a/src/usbd_stm32wb55_devfs.c
+++ b/src/usbd_stm32wb55_devfs.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "stm32.h"
+#include "stm32_compat.h"
 #include "usb.h"
 
 #if defined(USBD_STM32WB55)


### PR DESCRIPTION
Regarding `stm32_compat.h`: since using both [stm32h](https://github.com/dmitrystu/stm32h) and pio at the same time would lead to code duplication, I thought this would be a good middle ground to have both Makefile and pio supported at the same time.

Closes #49.