### PR TITLE
STM32L433: Make double buffer work for bulk endpoints in ep_write

### DIFF
--- a/src/usbd_stm32l433_devfs.c
+++ b/src/usbd_stm32l433_devfs.c
@@ -352,6 +352,7 @@ static int32_t ep_write(uint8_t ep, const void *buf, uint16_t blen) {
     switch (*reg & (USB_EPTX_STAT | USB_EP_T_FIELD | USB_EP_KIND)) {
     /* doublebuffered bulk endpoint */
     case (USB_EP_TX_NAK   | USB_EP_BULK | USB_EP_KIND):
+    case (USB_EP_TX_VALID | USB_EP_BULK | USB_EP_KIND):
         if (*reg & USB_EP_SWBUF_TX) {
             pma_write(buf, blen, &(tbl->tx1));
         } else {


### PR DESCRIPTION
Hello,
thank you very much for the library.
While using the lib for implementing USB mass storage, I failed to get a bulk endpoint to work with USB_EPTYPE_DBLBUF set in usbd_ep_config for endpoint 0x81.
It turns out the endpoint is in the state USB_EP_TX_VALID and not USB_EP_TX_NAK. In both states data can be written.
Without double buffering the transfer rate to the host was limited to ~100KB/s. With double buffering, I can reach ~1100KB/s.
I tested the code with a STM32L452. I guess some of the the other drivers needs a similar fix, if required I could test it with a STM32F042 too.

(Should anyone look through the pull request in order to figure out how to use the lib correctly (as I did), my mass storage implementation can be found here: https://github.com/Solartraveler/UniversalboxArm/tree/main/src/stm32l452/06-usb-mass-storage )

Malte
