### PR TITLE
HID keyboard key name fix

### DIFF
--- a/inc/hid_usage_keyboard.h
+++ b/inc/hid_usage_keyboard.h
@@ -78,7 +78,7 @@
 #define HID_KEYBOARD_SEMICOLON          0x33
 #define HID_KEYBOARD_APOSTROPHE         0x34
 #define HID_KEYBOARD_GRAVE_ACCENT       0x35
-#define HID_KEYBOARD_COLON              0x36
+#define HID_KEYBOARD_COMMA              0x36
 #define HID_KEYBOARD_DOT                0x37
 #define HID_KEYBOARD_SLASH              0x38
 #define HID_KEYBOARD_CAPS_LOCK          0x39


### PR DESCRIPTION
Fixed typo in keyboard usage table, key with id 0x36 is a comma/< key