### PR TITLE
Fix sign-compare warning

### DIFF
--- a/src/usbd_stm32f103_devfs.c
+++ b/src/usbd_stm32f103_devfs.c
@@ -153,7 +153,7 @@ static uint16_t get_next_pma(uint16_t sz) {
         if ((tbl->tx.addr) && (tbl->tx.addr < _result)) _result = tbl->tx.addr;
         if ((tbl->rx.addr) && (tbl->rx.addr < _result)) _result = tbl->rx.addr;
     }
-    return (_result < (0x020 + sz)) ? 0 : (_result - sz);
+    return (_result < (0x020U + sz)) ? 0 : (_result - sz);
 }
 
 static uint32_t getinfo(void) {

--- a/src/usbd_stm32l052_devfs.c
+++ b/src/usbd_stm32l052_devfs.c
@@ -101,7 +101,7 @@ static uint16_t get_next_pma(uint16_t sz) {
         if ((tbl->rx.addr) && (tbl->rx.addr < _result)) _result = tbl->rx.addr;
         if ((tbl->tx.addr) && (tbl->tx.addr < _result)) _result = tbl->tx.addr;
     }
-    return (_result < (0x020 + sz)) ? 0 : (_result - sz);
+    return (_result < (0x020U + sz)) ? 0 : (_result - sz);
 }
 
 static uint32_t getinfo(void) {

--- a/src/usbd_stm32l100_devfs.c
+++ b/src/usbd_stm32l100_devfs.c
@@ -90,7 +90,7 @@ static uint16_t get_next_pma(uint16_t sz) {
         if ((tbl->tx.addr) && (tbl->tx.addr < _result)) _result = tbl->tx.addr;
         if ((tbl->rx.addr) && (tbl->rx.addr < _result)) _result = tbl->rx.addr;
     }
-    return (_result < (0x020 + sz)) ? 0 : (_result - sz);
+    return (_result < (0x020U + sz)) ? 0 : (_result - sz);
 }
 
 static uint32_t getinfo(void) {

--- a/src/usbd_stm32l433_devfs.c
+++ b/src/usbd_stm32l433_devfs.c
@@ -94,7 +94,7 @@ static uint16_t get_next_pma(uint16_t sz) {
         if ((tbl->rx.addr) && (tbl->rx.addr < _result)) _result = tbl->rx.addr;
         if ((tbl->tx.addr) && (tbl->tx.addr < _result)) _result = tbl->tx.addr;
     }
-    return (_result < (0x020 + sz)) ? 0 : (_result - sz);
+    return (_result < (0x020U + sz)) ? 0 : (_result - sz);
 }
 
 static uint32_t getinfo(void) {

--- a/src/usbd_stm32wb55_devfs.c
+++ b/src/usbd_stm32wb55_devfs.c
@@ -94,7 +94,7 @@ static uint16_t get_next_pma(uint16_t sz) {
         if ((tbl->rx.addr) && (tbl->rx.addr < _result)) _result = tbl->rx.addr;
         if ((tbl->tx.addr) && (tbl->tx.addr < _result)) _result = tbl->tx.addr;
     }
-    return (_result < (unsigned)(0x020 + sz)) ? 0 : (_result - sz);
+    return (_result < (0x020U + sz)) ? 0 : (_result - sz);
 }
 
 static uint32_t getinfo(void) {


### PR DESCRIPTION
I applied the same fix for every devfs driver (and simplified the `stm32wb55` existing fix), but please note that I only tested the `stm32l433` driver, using a `stm32g341`, however this change should be trivial and not cause any harm.