### PR TITLE
fix(hid_usage_simulation.h): invalid include guard

### DIFF
--- a/inc/hid_usage_simulation.h
+++ b/inc/hid_usage_simulation.h
@@ -14,7 +14,7 @@
  */
 
 #ifndef _USB_HID_USAGE_SIMUL_H_
-#define _USB_HID_USAHE_SUMUL_H_
+#define _USB_HID_USAGE_SIMUL_H_
 #ifdef __cplusplus
     extern "C" {
 #endif


### PR DESCRIPTION
# Description

This fixes the invalid include guard in `inc/hid_usage_simulation.h`.

# Background

This was discovered by clang when building bindings for [flipperzero-rs].

```log
clang diag: /app/firmware/build/f7-firmware-D/sdk_headers//f7_sdk/lib/libusb_stm32/inc/hid_usage_simulation.h:16:9: warning: '_USB_HID_USAGE_SIMUL_H_' is used as a header guard here, followed by #define of a different macro [-Wheader-guard]
```

[flipperzero-rs]: https://github.com/flipperzero-rs/flipperzero/