### PR TITLE
Document the usbd_ep_write(dev, ep, 0, 0) trick

### DIFF
--- a/inc/usbd_core.h
+++ b/inc/usbd_core.h
@@ -269,6 +269,11 @@ typedef int32_t (*usbd_hw_ep_read)(uint8_t ep, void *buf, uint16_t blen);
  * \param buf pointer to data buffer
  * \param blen size of data will be written
  * \return number of written bytes
+ *
+ * The \ref usbd_evt_eptx event will fire for the endpoint once the
+ * write is \e complete. A trick commonly used is to enqueue a zero-length
+ * write as soon as the endpoint is configured, so that it would
+ * "complete", firing an event, the next time an IN request arrives.
  */
 typedef int32_t (*usbd_hw_ep_write)(uint8_t ep, const void *buf, uint16_t blen);
 


### PR DESCRIPTION
Hello and thank you for the wonderfully compact library! After `STM32_USB_Device_Library`, it's a pleasure to use.

It takes a while to figure out how to use the code properly (took me a few evenings to find out when the `usbd_evt_eprx` events should actually arrive for my endpoint), so I would like to introduce some more documentation. I can expand this pull request with more information if that is desirable. Please let me know what you think.